### PR TITLE
Feature#13 url domain overwrite no readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - 📫 If you want to reach me, [send me a message][twitter]
 - ⚡ Fun fact: I recently joined [#100DaysOfCode](https://www.100daysofcode.com/) and [#100DaysOfMeditation](https://www.100daysofx.com/where-x-is/meditation/)
 
-[![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=ediazjz&count_private=true&theme=dark&show_icons=true)](https://github.com/ediazjz/github-readme-stats)
+[![Edgar Diaz's github stats](https://github-readme-stats.vercel.app/api?username=ediazjz&count_private=true&theme=dark&show_icons=true)](https://ediazjz.dev/github-readme-stats)
 
 [website]: https://ediazjz.dev
 [twitter]: https://twitter.com/ediazjz

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  async rewrites() {
+    return [
+      {
+        source: '/github-readme-status',
+        destination: 'https://github-readme-stats.vercel.app/api?username=ediazjz&count_private=true&theme=dark&show_icons=true',
+      },
+    ]
+  },
+}


### PR DESCRIPTION
# Description
I set up the path `/github-readme-stats`to my implementation of GitHub Readme Stats project on Vercel.
I discover in #11 that changing the source of README Stats to my domain did not render the component on my README.md, so now i just changed the link to which the user is redirected when clicking on the Stats